### PR TITLE
Prevent broken background under small width

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,7 +54,7 @@ body {
 }
 
 .container {
-  width: 1000px;
+  width: 1080px;
   margin: 0 auto;
 }
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -107,6 +107,7 @@ export default class Home extends Vue {
 
 <style lang="scss" scoped>
 .home {
+  min-width: 1080px;
   .home-carousel-container {
     background-color: #222;
     height: 500px;


### PR DESCRIPTION
브라우저 width 작은 경우에 백그라운 설정이 깨지는 문제 해결. 
before: https://www.dropbox.com/s/tjht9m15o1riyrq/chrome_2019-02-20_15-47-40.gif?dl=0
after: https://www.dropbox.com/s/a2cayj9vbk6mc11/chrome_2019-02-20_15-47-16.gif?dl=0